### PR TITLE
fix: rename InclutionTypes to InclusionTypes (Stardust 5.7.x compat)

### DIFF
--- a/src/Veracity.Services.Api/ICompaniesDirectory.cs
+++ b/src/Veracity.Services.Api/ICompaniesDirectory.cs
@@ -18,11 +18,11 @@ namespace Veracity.Services.Api
     {
         [Get("companies/{id}", "Get the detailed company description")]
         [AccessControllGate(AccessControllTypes.ServiceThenUser, RoleTypes.ReadDirectoryAccess)]
-        Task<CompanyInfo> CompanyById([In(InclutionTypes.Path)] string id);
+        Task<CompanyInfo> CompanyById([In(InclusionTypes.Path)] string id);
 
         [Get("companies/{id}/users", "Get users affiliated with the company. Paged query: uses 0 based page index")]
         [AccessControllGate(AccessControllTypes.ServiceThenUser, RoleTypes.ReadDirectoryAccess)]
-        Task<IEnumerable<UserReference>> GetUsersByCompany([In(InclutionTypes.Path)] string id, [In(InclutionTypes.Path)] int page, [In(InclutionTypes.Path)] int pageSize);
+        Task<IEnumerable<UserReference>> GetUsersByCompany([In(InclusionTypes.Path)] string id, [In(InclusionTypes.Path)] int page, [In(InclusionTypes.Path)] int pageSize);
 
     }
 }

--- a/src/Veracity.Services.Api/IMy.cs
+++ b/src/Veracity.Services.Api/IMy.cs
@@ -31,16 +31,16 @@ namespace Veracity.Services.Api
 
         [Get("messages", "Read the users messages. All: include read messages. ImportantOnly: only include important messages")]
         [AccessControllGate(AccessControllTypes.User, RoleTypes.IsValidUser)]
-        Task<IEnumerable<MessageReference>> GetMessagesAsync([In(InclutionTypes.Path)] bool all, [InHeader] string importantOnly = null);
+        Task<IEnumerable<MessageReference>> GetMessagesAsync([In(InclusionTypes.Path)] bool all, [InHeader] string importantOnly = null);
 
         [Patch("messages", "Marks all unread messages as read. ImportantOnly: only mark important messages as read")]
-        Task MarkAllMessagesAsRead([In(InclutionTypes.Header)] string importantOnly = null);
+        Task MarkAllMessagesAsRead([In(InclusionTypes.Header)] string importantOnly = null);
 
         //Notice the In attribute for the parameters, it is equivalent with FromBody and FromUri and is required (it currently defaults to FromBody :(  )
         [Get("messages/{messageId}")]
         [AccessControllGate(AccessControllTypes.User, RoleTypes.IsValidUser)]
         [Obsolete]
-        Task<Message> GetMessageAsync([In(InclutionTypes.Path)] string messageId);
+        Task<Message> GetMessageAsync([In(InclusionTypes.Path)] string messageId);
 
         [Patch("messages/{messageId}")]
         [Obsolete]
@@ -54,16 +54,16 @@ namespace Veracity.Services.Api
         [Get("policies/{serviceId}/validate()", "Validates all myDnvgl policies and returns a list of the policies that needs attention")]
         [AccessControllGate(AccessControllTypes.User, RoleTypes.IsValidUser)]
         [AuthorizeWrapper]
-        Task ValidatePolicy([In(InclutionTypes.Path)] string serviceId, [In(InclutionTypes.Header)]string returnUrl,  [InHeader]string skipSubscriptionCheck);
+        Task ValidatePolicy([In(InclusionTypes.Path)] string serviceId, [In(InclusionTypes.Header)]string returnUrl,  [InHeader]string skipSubscriptionCheck);
 
         [Get("policies/validate()", "Validates all myDnvgl policies and returns a list of the policies that needs attention")]
         [AccessControllGate(AccessControllTypes.User, RoleTypes.IsValidUser)]
         [AuthorizeWrapper]
-        Task ValidatePolicies([In(InclutionTypes.Header)]string returnUrl);
+        Task ValidatePolicies([In(InclusionTypes.Header)]string returnUrl);
 
         [Get("services", "Returns all services for the user inside the tenant with id:tenantId. System tenant id is Guid.empty. if tenantId is null, it will return all services from all tenants include system tenant.")]
         [AccessControllGate(AccessControllTypes.User, RoleTypes.IsValidUser)]
         [AuthorizeWrapper]
-        Task<IEnumerable<MyServiceReference>> MyServices([In(InclutionTypes.Header)] string tenantId = null);
+        Task<IEnumerable<MyServiceReference>> MyServices([In(InclusionTypes.Header)] string tenantId = null);
     }
 }

--- a/src/Veracity.Services.Api/IOptions.cs
+++ b/src/Veracity.Services.Api/IOptions.cs
@@ -17,7 +17,7 @@ namespace Veracity.Services.Api
 		Task GetViewPoints();
 
 		[Options("options/{viewPoint}", "Provides CORS requirements and details about the viewpoints")]
-		Task GetOptions1([In(InclutionTypes.Path)] string viewPoint);
+		Task GetOptions1([In(InclusionTypes.Path)] string viewPoint);
 
 		[Options("options")]
 		Task GetOptions();
@@ -28,6 +28,6 @@ namespace Veracity.Services.Api
 
 		[Get("cache/invalidate/{id}", "Invalidate the cached item with the provided id")]
 		[AuthorizeWrapper]
-		Task InvalidateCache([In(InclutionTypes.Path)]string id);
+		Task InvalidateCache([In(InclusionTypes.Path)]string id);
 	}
 }

--- a/src/Veracity.Services.Api/IServicesDirectory.cs
+++ b/src/Veracity.Services.Api/IServicesDirectory.cs
@@ -20,15 +20,15 @@ namespace Veracity.Services.Api
     {
         [Get("services/{id}", "Get the detailed service description by the provided id")]
         [AccessControllGate(AccessControllTypes.ServiceThenUser, RoleTypes.ReadDirectoryAccess)]
-        Task<ServiceInfo> GetServiceById([In(InclutionTypes.Path)] string id, [In(InclutionTypes.Header)] string tenantId = null);
+        Task<ServiceInfo> GetServiceById([In(InclusionTypes.Path)] string id, [In(InclusionTypes.Header)] string tenantId = null);
 
 
         [Get("services/{id}/users", "Get the list of users subscribing to the service. Paged query: uses 0 based page index")]
         [AccessControllGate(AccessControllTypes.ServiceThenUser, RoleTypes.ReadDirectoryAccess)]
-        Task<IEnumerable<UserReference>> GetUsers([In(InclutionTypes.Path)] string id, [In(InclutionTypes.Path)] int page, [In(InclutionTypes.Path)] int pageSize, [In(InclutionTypes.Header)] string tenantId = null);
+        Task<IEnumerable<UserReference>> GetUsers([In(InclusionTypes.Path)] string id, [In(InclusionTypes.Path)] int page, [In(InclusionTypes.Path)] int pageSize, [In(InclusionTypes.Header)] string tenantId = null);
 
         [Get("services/{serviceId}/administrators/{userId}","Internal only")]
         [Obsolete("Only for Veracity internal usage, this will be removed at a later stage", false)]
-        Task<bool> IsAdmin([In(InclutionTypes.Path)] string userId, [In(InclutionTypes.Path)] string serviceId);
+        Task<bool> IsAdmin([In(InclusionTypes.Path)] string userId, [In(InclusionTypes.Path)] string serviceId);
     }
 }

--- a/src/Veracity.Services.Api/IThis.cs
+++ b/src/Veracity.Services.Api/IThis.cs
@@ -18,77 +18,77 @@ namespace Veracity.Services.Api
     {
         [Get("services", "Get all services the service principal has access to. Currently not 100% accurate. Paged query: uses 0 based page index")]
         [AccessControllGate(AccessControllTypes.UserAndService, RoleTypes.ReadAccess)]
-        Task<IEnumerable<ServiceReference>> GetServices([In(InclutionTypes.Path)] int page, [In(InclutionTypes.Path)] int pageSize);
+        Task<IEnumerable<ServiceReference>> GetServices([In(InclusionTypes.Path)] int page, [In(InclusionTypes.Path)] int pageSize);
 
         [Get("subscribers", "Get all users with a subscription to this servicein the tenant if provided, or it will get from system tenant. Paged query: uses 0 based page index", Summary = Constants.Warning300)]
         [AccessControllGate(AccessControllTypes.UserAndService, RoleTypes.ReadAccess)]
-        Task<IEnumerable<UserReference>> GetUsers([In(InclutionTypes.Path)] int page, [In(InclutionTypes.Path)] int pageSize, [InHeader] string tenantId = null);
+        Task<IEnumerable<UserReference>> GetUsers([In(InclusionTypes.Path)] int page, [In(InclusionTypes.Path)] int pageSize, [InHeader] string tenantId = null);
 
         [Get("subscribers/{userId}", "Get all subscription to this user in the tenant if provided, or it will get from system tenant.", Summary = Constants.Warning300)]
         [AccessControllGate(AccessControllTypes.UserAndService, RoleTypes.ReadAccess)]
-        Task<SubscriptionReference> GetServiceUser([In(InclutionTypes.Path)] string userId, [InHeader] string tenantId = null);
+        Task<SubscriptionReference> GetServiceUser([In(InclusionTypes.Path)] string userId, [InHeader] string tenantId = null);
 
         [Get("services/{serviceId}/subscribers/{userId}", "Checks if a user has a subscription to the service and the access level if any in the tenant if provided, or it will get from system tenant.", Summary = Constants.Warning300)]
         [AccessControllGate(AccessControllTypes.UserAndService, RoleTypes.ReadAccess)]
-        Task<SubscriptionReference> GetUserForService([InPath]string serviceId, [In(InclutionTypes.Path)] string userId, [InHeader] string tenantId = null);
+        Task<SubscriptionReference> GetUserForService([InPath]string serviceId, [In(InclusionTypes.Path)] string userId, [InHeader] string tenantId = null);
 
         [Get("services/{serviceId}/subscribers", "Get all users with a subscription to this service in the tenant if provided, or it will get from system tenant. Paged query: uses 0 based page index")]
         [AccessControllGate(AccessControllTypes.UserAndService, RoleTypes.ReadAccess, ParameterIndex = 0)]
-        Task<IEnumerable<UserReference>> GetServiceUsers([In(InclutionTypes.Path)]string serviceId, [In(InclutionTypes.Path)] int page, [In(InclutionTypes.Path)] int pageSize, [InHeader] string tenantId = null);
+        Task<IEnumerable<UserReference>> GetServiceUsers([In(InclusionTypes.Path)]string serviceId, [In(InclusionTypes.Path)] int page, [In(InclusionTypes.Path)] int pageSize, [InHeader] string tenantId = null);
 
         [Put("subscribers/{userId}", "Add a user subscription to the service in the tenant if provided, or it will use system tenant", Summary = Constants.Warning300)]
         [AccessControllGate(AccessControllTypes.UserAndService, RoleTypes.ManageServiceSubscriptions)]
-        Task AddUserAsync([In(InclutionTypes.Path)] string userId, [In(InclutionTypes.Body)] SubscriptionOptions options, [InHeader] string tenantId = null);
+        Task AddUserAsync([In(InclusionTypes.Path)] string userId, [In(InclusionTypes.Body)] SubscriptionOptions options, [InHeader] string tenantId = null);
 
         [Put("services/{serviceId}/subscribers/{userId}", "Add a user subscription to the service with the provided id in the tenant if provided, or it will use system tenant. Only available for the root service for nested services")]
         [AccessControllGate(AccessControllTypes.UserAndService, RoleTypes.ManageServiceSubscriptions, ParameterIndex = 1)]
-        Task AddServiceUser([In(InclutionTypes.Path)] string userId, [In(InclutionTypes.Path)] string serviceId, [In(InclutionTypes.Body)] SubscriptionOptions options, [InHeader] string tenantId = null);
+        Task AddServiceUser([In(InclusionTypes.Path)] string userId, [In(InclusionTypes.Path)] string serviceId, [In(InclusionTypes.Body)] SubscriptionOptions options, [InHeader] string tenantId = null);
 
         [Delete("services/{serviceId}/subscribers/{userId}", "Remove servive subscription from the user in the tenant if provided, or it will use system tenant. Only available for the root service for nested services")]
         [AccessControllGate(AccessControllTypes.UserAndService, RoleTypes.ManageServiceSubscriptions, ParameterIndex = 1)]
-        Task RemoveServiceUser([In(InclutionTypes.Path)] string userId, [In(InclutionTypes.Path)] string serviceId, [InHeader] string tenantId = null);
+        Task RemoveServiceUser([In(InclusionTypes.Path)] string userId, [In(InclusionTypes.Path)] string serviceId, [InHeader] string tenantId = null);
 
         [Delete("subscribers/{userId}", "Remove servive subscription for the user from this service in the tenant if provided, or it will use system tenant.", Summary = Constants.Warning300)]
         [AccessControllGate(AccessControllTypes.UserAndService, RoleTypes.ManageServiceSubscriptions)]
-        Task RemoveUser([In(InclutionTypes.Path)] string userId, [InHeader] string tenantId = null);
+        Task RemoveUser([In(InclusionTypes.Path)] string userId, [InHeader] string tenantId = null);
 
         [Get("user/resolve({email})", "Get the user id from the email address", Summary = "Note that an email address may be connected to more than one user account")]
         [AccessControllGate(AccessControllTypes.ServiceThenUser, RoleTypes.ManageServiceSubscriptions)]
-        Task<UserReference[]> ResolveUser([In(InclutionTypes.Path)] string email);
+        Task<UserReference[]> ResolveUser([In(InclusionTypes.Path)] string email);
 
         [Post("user", "Create a user in Veracity")]
         [AccessControllGate(AccessControllTypes.ServiceThenUser, RoleTypes.ManageServiceSubscriptions)]
-        Task<UserCreationReference> CreateUser([In(InclutionTypes.Body)] UserRegistration user);
+        Task<UserCreationReference> CreateUser([In(InclusionTypes.Body)] UserRegistration user);
 
         [Post("users", "Create users in Veracity")]
         [AccessControllGate(AccessControllTypes.UserAndService, RoleTypes.ManageServiceSubscriptions)]
-        Task<UserCreationReference[]> CreateUsers([In(InclutionTypes.Body)] UserRegistration[] user);
+        Task<UserCreationReference[]> CreateUsers([In(InclusionTypes.Body)] UserRegistration[] user);
 
         [Get("administrators", "Get all users with a subscription to this service. Paged query: uses 0 based page index", Summary = Constants.Warning300)]
         [AccessControllGate(AccessControllTypes.UserAndService, RoleTypes.ReadAccess)]
-        Task<IEnumerable<AdminReference>> GetAdmins([In(InclutionTypes.Path)] int page, [In(InclutionTypes.Path)] int pageSize);
+        Task<IEnumerable<AdminReference>> GetAdmins([In(InclusionTypes.Path)] int page, [In(InclusionTypes.Path)] int pageSize);
 
         [Get("administrators/{userId}", "Get all users with a subscription to this service", Summary = Constants.Warning300)]
         [AccessControllGate(AccessControllTypes.UserAndService, RoleTypes.ReadAccess)]
-        Task<AdminInfo> GetAdmin([In(InclutionTypes.Path)] string userId);
+        Task<AdminInfo> GetAdmin([In(InclusionTypes.Path)] string userId);
 
         [Get("services/{serviceId}/administrators/{userId}", "Get all users with a subscription to this service")]
         [AccessControllGate(AccessControllTypes.UserAndService, RoleTypes.ReadAccess, ParameterIndex = 0)]
-        Task<AdminInfo> GetServiceAdmin([In(InclutionTypes.Path)] string serviceId, [In(InclutionTypes.Path)] string userId);
+        Task<AdminInfo> GetServiceAdmin([In(InclusionTypes.Path)] string serviceId, [In(InclusionTypes.Path)] string userId);
 
         [Get("services/{serviceId}/administrators", "Get all users with a subscription to this service. Paged query: uses 0 based page index")]
         [AccessControllGate(AccessControllTypes.UserAndService, RoleTypes.ReadAccess, ParameterIndex = 0)]
-        Task<IEnumerable<AdminReference>> GetServiceAdmins([In(InclutionTypes.Path)] string serviceId, [In(InclutionTypes.Path)] int page, [In(InclutionTypes.Path)] int pageSize);
+        Task<IEnumerable<AdminReference>> GetServiceAdmins([In(InclusionTypes.Path)] string serviceId, [In(InclusionTypes.Path)] int page, [In(InclusionTypes.Path)] int pageSize);
 
         [Post("services/{serviceId}/notification", "Send notification to your users through the Veracity notification service")]
         [AccessControllGate(AccessControllTypes.ServiceThenUser, RoleTypes.ReadAccess, ParameterIndex = 0)]
-        Task NotifyUsers([InPath] string serviceId, [In(InclutionTypes.Body)] NotificationMessage message, [InHeader] string channelId);
+        Task NotifyUsers([InPath] string serviceId, [In(InclusionTypes.Body)] NotificationMessage message, [InHeader] string channelId);
 
         [Get("services/{serviceId}/subscribers/{userId}/picture", "Gets the profile picture of the user if there is a subscription and the user has uploaded a profile picture to veracity")]
         [AccessControllGate(AccessControllTypes.ServiceThenUser, RoleTypes.ReadAccess)]
-        Task<ProfilePicture> GetUserProfilePicture([InPath] string serviceId, [In(InclutionTypes.Path)] string userId);
+        Task<ProfilePicture> GetUserProfilePicture([InPath] string serviceId, [In(InclusionTypes.Path)] string userId);
 
         [Get("services/{serviceId}/subscribers/{userId}/policy/validate()")]
-        Task VerifySubscriberPolicy([In(InclutionTypes.Path)] string serviceId, [In(InclutionTypes.Path)] string userId, [In(InclutionTypes.Header)] string returnUrl, [InHeader] string skipSubscriptionCheck);
+        Task VerifySubscriberPolicy([In(InclusionTypes.Path)] string serviceId, [In(InclusionTypes.Path)] string userId, [In(InclusionTypes.Header)] string returnUrl, [InHeader] string skipSubscriptionCheck);
     }
 }

--- a/src/Veracity.Services.Api/IUsersDirectory.cs
+++ b/src/Veracity.Services.Api/IUsersDirectory.cs
@@ -19,29 +19,29 @@ namespace Veracity.Services.Api
     {
         [Get("email/", "Gets a list of users with a given email address")]
         [AccessControllGate(AccessControllTypes.ServiceThenUser, RoleTypes.ReadDirectoryAccess)]
-        Task<IEnumerable<UserReference>> GetUsersByEmail([In(InclutionTypes.Path)] string email);
+        Task<IEnumerable<UserReference>> GetUsersByEmail([In(InclusionTypes.Path)] string email);
 
         [Get("{id}", "Returns the full profile for the user with the provided id")]
         [AccessControllGate(AccessControllTypes.ServiceThenUser, RoleTypes.ReadDirectoryAccess)]
-        Task<UserInfo> GetUser([In(InclutionTypes.Path)] string id);
+        Task<UserInfo> GetUser([In(InclusionTypes.Path)] string id);
 
         [Post("", "Get full user profiles for a list of userid's", Summary = "Read multiple users profile")]
         [AccessControllGate(AccessControllTypes.ServiceThenUser, RoleTypes.ReadDirectoryAccess)]
-        Task<UserInfo[]> GetUsersIn([In(InclutionTypes.Body)] string[] ids);
+        Task<UserInfo[]> GetUsersIn([In(InclusionTypes.Body)] string[] ids);
 
 
 
         [Get("{userid}/companies", "Returns a list of companies tied to a spescified user.")]
         [AccessControllGate(AccessControllTypes.ServiceThenUser, RoleTypes.ReadDirectoryAccess)]
-        Task<IEnumerable<CompanyReference>> GetUserCompanies([In(InclutionTypes.Path)] string userid);
+        Task<IEnumerable<CompanyReference>> GetUserCompanies([In(InclusionTypes.Path)] string userid);
 
         [Get("{userid}/services", "Get a list of the users servcies in the tenant if provided, or it will use system tenant. Paged query: uses 0 based page index")]
         [AccessControllGate(AccessControllTypes.ServiceThenUser, RoleTypes.ReadDirectoryAccess)]
-        Task<IEnumerable<ServiceReference>> GetUserServices([In(InclutionTypes.Path)] string userid, [In(InclutionTypes.Path)] int page, [In(InclutionTypes.Path)] int pageSize, [InHeader] string tenantId = null);
+        Task<IEnumerable<ServiceReference>> GetUserServices([In(InclusionTypes.Path)] string userid, [In(InclusionTypes.Path)] int page, [In(InclusionTypes.Path)] int pageSize, [InHeader] string tenantId = null);
 
         [Get("{userid}/services/{serviceId}", "Gets the subscription state for a user with respect to the service provided in the tenant if provided, or it will use system tenant.")]
         [AccessControllGate(AccessControllTypes.ServiceThenUser, RoleTypes.ReadDirectoryAccess)]
-        Task<SubscriptionDetails> GetUserSubscriptionDetails([In(InclutionTypes.Path)] string userid, [In(InclutionTypes.Path)] string serviceId, [InHeader] string tenantId = null);
+        Task<SubscriptionDetails> GetUserSubscriptionDetails([In(InclusionTypes.Path)] string userid, [In(InclusionTypes.Path)] string serviceId, [InHeader] string tenantId = null);
 
 
     }


### PR DESCRIPTION
## Summary
Renames all occurrences of `InclutionTypes` to `InclusionTypes` across 6 interface files.

Stardust 5.7.x renamed the enum `InclutionTypes` → `InclusionTypes` (fixing a typo). This breaks all consumers that reference the old name. This PR updates the Veracity.Services.Api interfaces to use the corrected name.

## Files Changed
- `ICompaniesDirectory.cs`  
- `IMy.cs`  
- `IOptions.cs`  
- `IServicesDirectory.cs`  
- `IThis.cs`  
- `IUsersDirectory.cs`  

## Related
- Azure DevOps WI: [#753914](https://dev.azure.com/dnvgl-one/Veracity/_workitems/edit/753914)
- Stardust 5.7.x breaking change: enum rename InclutionTypes → InclusionTypes