### PR TITLE
chore: bump Veracity.Services.Api version to 3.7.0

### DIFF
--- a/src/Veracity.Services.Api/Veracity.Services.Api.csproj
+++ b/src/Veracity.Services.Api/Veracity.Services.Api.csproj
@@ -1,8 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
-    <Version>3.6.5</Version>
+    <Version>3.7.0</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Company>DNVGL</Company>
     <Authors>Veracity by DNVGL</Authors>


### PR DESCRIPTION
## Summary

Bumps `Veracity.Services.Api` package version from `3.6.5` to `3.7.0`.

**Why:** PR #45 renamed `InclutionTypes` to `InclusionTypes` (breaking API change to match Stardust 5.7.x), but the version was not bumped. The [ApiV3-nuget-push pipeline](https://dev.azure.com/dnvgl-one/e330e6a2-b156-41b4-b146-fddaccd1dd2b/_build/results?buildId=2309354) returned 409 Conflict because `3.6.5` already exists on nuget.org.

**Impact:** Once merged and the pipeline is re-run, downstream consumers (`ECO_CommonLibraries`, `ECO_Services_Api`) can upgrade to Stardust 5.7.x + `Veracity.Services.Api` 3.7.0 together.

## Changes

- `src/Veracity.Services.Api/Veracity.Services.Api.csproj`: `3.6.5` -> `3.7.0`