### PR TITLE
fix: bump Stardust to 5.7.x for InclusionTypes rename compatibility

### DIFF
--- a/src/Veracity.Services.Api/Veracity.Services.Api.csproj
+++ b/src/Veracity.Services.Api/Veracity.Services.Api.csproj
@@ -29,8 +29,8 @@ increased the error limit for the CircuitBreaker
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Stardust.Interstellar.Rest" Version="5.5.3" />
-    <PackageReference Include="Stardust.Interstellar.Rest.Annotations" Version="5.5.1" />
+    <PackageReference Include="Stardust.Interstellar.Rest" Version="5.7.2" />
+    <PackageReference Include="Stardust.Interstellar.Rest.Annotations" Version="5.7.1" />
     <PackageReference Include="Stardust.Particles" Version="5.0.2" />
   </ItemGroup>
 


### PR DESCRIPTION
## Summary

Bumps Stardust dependencies to 5.7.x to fix the build broken by PR #45.

**Root cause:** PR #45 renamed `InclutionTypes` to `InclusionTypes` to match Stardust 5.7.x API, and PR #46 bumped the package version to 3.7.0 -- but the Stardust `PackageReference` versions were not updated. The [ApiV3-nuget-push build #2309656](https://dev.azure.com/dnvgl-one/e330e6a2-b156-41b4-b146-fddaccd1dd2b/_build/results?buildId=2309656) failed with `CS0103: The name 'InclusionTypes' does not exist in the current context` because Stardust 5.5.x still uses the old `InclutionTypes` name.

## Changes

- `Stardust.Interstellar.Rest`: 5.5.3 -> 5.7.2
- `Stardust.Interstellar.Rest.Annotations`: 5.5.1 -> 5.7.1